### PR TITLE
Load labextensions from EDC conda environment

### DIFF
--- a/Dockerfile-jupyter-user-base
+++ b/Dockerfile-jupyter-user-base
@@ -247,3 +247,6 @@ RUN conda config --system --set auto_activate_base false
 # Add custom edc jupyterlab config
 RUN mkdir /etc/jupyter/labconfig
 COPY ./jupyter-user/page_config.json /etc/jupyter/labconfig
+
+
+COPY jupyter_lab_config.py /etc/jupyter

--- a/Dockerfile-jupyter-user-base-g
+++ b/Dockerfile-jupyter-user-base-g
@@ -247,3 +247,6 @@ RUN conda config --system --set auto_activate_base false
 # Add custom edc jupyterlab config
 RUN mkdir /etc/jupyter/labconfig
 COPY ./jupyter-user/page_config.json /etc/jupyter/labconfig
+
+
+COPY jupyter_lab_config.py /etc/jupyter

--- a/jupyter_lab_config.py
+++ b/jupyter_lab_config.py
@@ -1,0 +1,8 @@
+import os
+# Configuration file for lab.
+
+## Extra paths to look for federated JupyterLab extensions
+if (env := os.environ.get("ENV_NAME")):
+    c.LabApp.extra_labextensions_path = [
+        f"/opt/conda/envs/{env}/share/jupyter/labextensions"
+    ]


### PR DESCRIPTION
- `jupyter-user-base` and `jupyter-user-base-g` must be bumped for this.
- Only fixes problem for `lab` (not for `notebook`)